### PR TITLE
Raise minimum dock icon size to 26px

### DIFF
--- a/prefs/pages/dockPage.js
+++ b/prefs/pages/dockPage.js
@@ -25,7 +25,7 @@ export function buildDockPage(window, s) {
     layout.add(spinRow(s, 'dock-scale', _('Overall scale'),
         _('Scales icons, padding and pill together'), 0.5, 2.0, 0.05, 2));
     layout.add(spinRow(s, 'icon-size', _('Icon size'),
-        _('Resting icon size in pixels'), 24, 128, 2, 0));
+        _('Resting icon size in pixels'), 26, 128, 2, 0));
     layout.add(spinRow(s, 'icon-spacing', _('Icon spacing'),
         _('Gap between neighbouring dock icons in pixels'), 0, 48, 1, 0));
     layout.add(spinRow(s, 'edge-margin', _('Edge gap'),


### PR DESCRIPTION
Changes the Dock preferences Icon size control minimum from 24px to 26px. The default remains 60px and the maximum remains 128px. This is intentionally limited to the user-selectable preferences bound; no runtime sizing behavior is otherwise changed.