### PR TITLE
Harden runtime lifecycle and settings updates

### DIFF
--- a/animation/animationEngine.js
+++ b/animation/animationEngine.js
@@ -125,6 +125,20 @@ export class AnimationEngine {
 
     kick() {
         if (!this._scheduler || this._suspended) return;
+
+        // Reduced-motion can change through the direct settings path without a
+        // relayout. Refresh the cached mode here so that change takes effect on
+        // the very next requested frame rather than waiting for setModel().
+        const animate = animationsEnabled();
+        if (animate !== this._animate) {
+            this._animate = animate;
+            if (!animate) {
+                this._scheduler.stop();
+                if (this._model) this._frame(0); // snap to the current target
+                return;
+            }
+        }
+
         if (!this._animate && !this._scheduler.isRunning()) return;
         this._scheduler.start();
     }

--- a/animation/frameScheduler.js
+++ b/animation/frameScheduler.js
@@ -5,8 +5,8 @@ import Clutter from 'gi://Clutter';
 
 import { logError } from '../core/utils.js';
 
-// Long enough to never naturally complete during a session; we drive by delta
-// and stop on settle, so the absolute duration is irrelevant beyond "huge".
+// The timeline repeats indefinitely while work exists; the scheduler explicitly
+// stops it as soon as the animation engine settles.
 const TIMELINE_DURATION_MS = 3600 * 1000;
 
 export class FrameScheduler {
@@ -27,6 +27,7 @@ export class FrameScheduler {
         this._timeline = new Clutter.Timeline({
             actor: this._actor,
             duration: TIMELINE_DURATION_MS,
+            repeat_count: -1,
         });
         this._frameId = this._timeline.connect('new-frame', () => {
             // Frame-clock delta in ms; clamp pathological gaps (resume/stall).

--- a/autohide/overlapDetector.js
+++ b/autohide/overlapDetector.js
@@ -44,6 +44,7 @@ export class OverlapDetector {
         const rh = vert ? geom.height : geom.thick;
 
         let overlapped = false;
+        const active = new Set();
         const actors = global.get_window_actors();
         for (let i = 0, len = actors.length; i < len; i++) {
             const win = actors[i].meta_window;
@@ -52,6 +53,7 @@ export class OverlapDetector {
             if (win.get_monitor() !== monIndex) continue;
             if (!HANDLED_TYPES.has(win.get_window_type())) continue;
 
+            active.add(win);
             if (!this._tracked.has(win)) this._track(win);
             if (overlapped) continue;   // keep tracking the rest, but answer known
 
@@ -59,6 +61,13 @@ export class OverlapDetector {
             if (f.x + TOL < rx + rw && f.x + f.width - TOL > rx &&
                 f.y + TOL < ry + rh && f.y + f.height - TOL > ry)
                 overlapped = true;
+        }
+
+        // Windows can stay alive while moving to another workspace/monitor.
+        // Stop retaining their move/resize signals as soon as they leave this
+        // detector's scope; they will be tracked again if they return.
+        for (const win of [...this._tracked]) {
+            if (!active.has(win)) this._untrack(win);
         }
         return overlapped;
     }

--- a/autohide/pressureBarrier.js
+++ b/autohide/pressureBarrier.js
@@ -69,19 +69,24 @@ export class PressureBarrier {
         try { p = global.get_pointer(); } catch { return; }
 
         const side = cfg.position;
+        const monR = mon.x + mon.width;
+        const monB = mon.y + mon.height;
         let edgeHit = false;
         if (side === 'left' || side === 'right') {
             // Vertical dock: lateral drift is on Y axis.
             const ddy = this._last ? (p[1] - this._last[1]) : 0;
             const dy = ddy * ddy;
+            const withinY = p[1] >= mon.y && p[1] < monB;
             edgeHit = side === 'left'
-                ? dy < LATERAL_AREA && p[0] < mon.x + EDGE_PX
-                : dy < LATERAL_AREA && p[0] > mon.x + mon.width - EDGE_PX;
+                ? withinY && dy < LATERAL_AREA && p[0] >= mon.x && p[0] < mon.x + EDGE_PX
+                : withinY && dy < LATERAL_AREA && p[0] >= monR - EDGE_PX && p[0] < monR;
         } else {
             // Bottom dock: lateral drift is on X axis.
             const ddx = this._last ? (p[0] - this._last[0]) : 0;
             const dx = ddx * ddx;
-            edgeHit = dx < LATERAL_AREA && p[1] >= mon.y + mon.height - EDGE_PX;
+            const withinX = p[0] >= mon.x && p[0] < monR;
+            edgeHit = withinX && dx < LATERAL_AREA &&
+                p[1] >= monB - EDGE_PX && p[1] < monB;
         }
 
         this._last = p;

--- a/dock/dockController.js
+++ b/dock/dockController.js
@@ -526,6 +526,13 @@ export class DockController {
             !GEOMETRY_KEYS.has(key) && hasKnownDirectSettingImpact(key));
 
         if (!direct) {
+            // Popups are anchored to current geometry and cache presentation
+            // settings at construction time. Close transient UI before a full
+            // relayout so nothing keeps an old anchor/style while the dock moves.
+            this._preview?.hide(true);
+            this._downloads?.closeStack();
+            this._menu?.closeNow();
+            this._tooltip?.hide();
             this.relayout();
             this._syncNotificationSubscription();
             this._refreshItems();
@@ -546,12 +553,25 @@ export class DockController {
         let autohideChanged = false;
         let tooltipChanged = false;
         let itemsChanged = false;
+        let previewChanged = false;
+        let downloadsChanged = false;
+        let menuChanged = false;
         for (const key of changed) {
             styleChanged ||= STYLE_KEYS.has(key);
             autohideChanged ||= AUTOHIDE_KEYS.has(key);
             tooltipChanged ||= TOOLTIP_KEYS.has(key);
             itemsChanged ||= ITEM_REFRESH_KEYS.has(key);
+            previewChanged ||= key === 'show-previews' || key.startsWith('preview-');
+            downloadsChanged ||= key.startsWith('downloads-');
+            menuChanged ||= key.startsWith('menu-');
         }
+
+        // Existing transient actors were built from the previous config. Close
+        // them instead of mutating live popup internals mid-animation; the next
+        // open reads the updated config and preserves the established visuals.
+        if (previewChanged) this._preview?.hide(true);
+        if (downloadsChanged) this._downloads?.closeStack();
+        if (menuChanged) this._menu?.closeNow();
 
         if (styleChanged)
             this._chrome.applyPillStyle(pillStyle(this._cfg));

--- a/dock/dockFactory.js
+++ b/dock/dockFactory.js
@@ -53,8 +53,12 @@ export class DockFactory {
         const nextItems = [];
         const nextChips = [];
         const createdActors = [];
+        const reused = [];
 
         try {
+            // Build the replacement structure first. Existing DockItems are not
+            // mutated until every new actor has been created successfully, so a
+            // constructor/factory failure cannot leave the old layout half-new.
             for (const entry of entries) {
                 if (entry.kind === 'separator' || entry.kind === 'spacer') {
                     const sep = new St.Widget({
@@ -69,9 +73,12 @@ export class DockFactory {
                 let item = oldByKey.get(entry.key);
                 if (item) {
                     oldByKey.delete(entry.key);
-                    item.entry = entry;
-                    if (!sameIcon(item.gicon, entry.gicon)) item.setGicon(entry.gicon);
-                    item.refresh();
+                    reused.push({
+                        item,
+                        entry,
+                        previousEntry: item.entry,
+                        previousGicon: item.gicon,
+                    });
                 } else {
                     item = new DockItem(entry, cfg);
                     createdActors.push(item);
@@ -80,6 +87,28 @@ export class DockFactory {
                 }
                 nextItems.push(item);
                 nextChips.push({ entry, actor: item, item, w: cfg.cellW });
+            }
+
+            // Commit metadata/icon refreshes only after construction succeeded.
+            // If a reused item refresh throws, restore every reused item before
+            // returning control to the still-valid old chip structure.
+            try {
+                for (const record of reused) {
+                    const { item, entry } = record;
+                    item.entry = entry;
+                    if (!sameIcon(item.gicon, entry.gicon)) item.setGicon(entry.gicon);
+                    item.refresh();
+                }
+            } catch (error) {
+                for (let i = reused.length - 1; i >= 0; i--) {
+                    const { item, previousEntry, previousGicon } = reused[i];
+                    try {
+                        item.entry = previousEntry;
+                        if (!sameIcon(item.gicon, previousGicon)) item.setGicon(previousGicon);
+                        item.refresh();
+                    } catch { }
+                }
+                throw error;
             }
         } catch (error) {
             for (let i = createdActors.length - 1; i >= 0; i--) {

--- a/downloads/downloadManager.js
+++ b/downloads/downloadManager.js
@@ -108,9 +108,11 @@ export class DownloadManager {
         this._gen = 0;
     }
 
-    get stackOpen() { return this._stack.isOpen; }
+    get stackOpen() { return this._stack?.isOpen ?? false; }
 
     enable() {
+        if (!this._stack && this._host)
+            this._stack = new DownloadsStack(this._host.getMonitor);
         if (!this._host.getConfig().showDownloads || this._watchUnsubscribe) return;
         this._watchUnsubscribe = subscribeDownloads(file => this._scheduleArrival(file));
     }
@@ -120,10 +122,17 @@ export class DownloadManager {
     }
 
     openFolderStack(item, folder, title = _('Folder'), gicon = null) {
+        if (!this._stack && this._host)
+            this._stack = new DownloadsStack(this._host.getMonitor);
+        if (!this._stack) return;
         const cfg = this._host.getConfig();
         try { item.bounce(Math.round(cfg.bounceHeight * 0.6), { decay: cfg.bounceDecay }); }
         catch { }
         this._stack.show(item, folder, cfg, () => this._host.onStackClosed?.(), { title, gicon });
+    }
+
+    closeStack() {
+        this._stack?.hide();
     }
 
     _scheduleArrival(file) {
@@ -271,7 +280,8 @@ export class DownloadManager {
             } catch { }
             this._flyer = null;
         }
-        this._stack.destroy();
+        this._stack?.destroy();
+        this._stack = null;
     }
 
     destroy() {

--- a/downloads/panelView.js
+++ b/downloads/panelView.js
@@ -73,7 +73,7 @@ export class PanelView {
         });
         this._actor = panel;
         if (cfg.highContrast) panel.add_style_class_name('aqua-high-contrast');
-        panel.add_child(this._header(folder, files.length));
+        panel.add_child(this._header(folder, this.totalFiles ?? files.length));
         panel.add_child(new St.Widget({ style_class: 'aqua-dl-divider' }));
 
         let box;

--- a/effects/genie/genieEffect.js
+++ b/effects/genie/genieEffect.js
@@ -12,6 +12,26 @@ import { clamp, appWindows, logError, TimeoutGroup } from '../../core/utils.js';
 // the override and restores the original value once the final animation ends.
 let slowDownOwner = null;
 let slowDownPrevious = 1;
+let slowDownApplied = null;
+
+function captureExternalSlowDownChange(stSettings) {
+    if (!slowDownOwner || slowDownApplied === null) return;
+    try {
+        const current = stSettings.slow_down_factor;
+        if (current !== slowDownApplied) slowDownPrevious = current;
+    } catch { }
+}
+
+function restoreSlowDown(stSettings) {
+    try {
+        // Do not overwrite a value another Shell component changed while the
+        // genie override was active.
+        if (slowDownApplied === null || stSettings.slow_down_factor === slowDownApplied)
+            stSettings.slow_down_factor = slowDownPrevious;
+    } catch { }
+    slowDownPrevious = 1;
+    slowDownApplied = null;
+}
 
 export class GenieController {
     // host: { getConfig, getGeom, getMonitorIndex, getChips, getItems }
@@ -100,6 +120,11 @@ export class GenieController {
         const dur = clamp(this._host.getConfig().genieDuration ?? 120, 50, 1000);
         const factor = clamp(dur / 250, 0.4, 4.0);
 
+        // If another Shell component changed the global factor while we owned
+        // it, preserve that newer value as the baseline before applying another
+        // genie override.
+        captureExternalSlowDownChange(stSettings);
+
         // Transfer ownership without restoring in between animations. Otherwise
         // a second dock could capture an already-overridden value and leave it
         // behind after both timer callbacks run.
@@ -111,14 +136,18 @@ export class GenieController {
         }
         slowDownOwner = this;
         this._cancelSlowDownRestore();
-        try { stSettings.slow_down_factor = factor; } catch { }
+        try {
+            stSettings.slow_down_factor = factor;
+            slowDownApplied = factor;
+        } catch {
+            slowDownApplied = null;
+        }
         try { fn(); } catch (e) { logError(e, 'genie fn'); }
         this._restoreId = this._timers.addOnce(dur + 60, () => {
             this._restoreId = 0;
             if (slowDownOwner !== this) return;
             slowDownOwner = null;
-            try { stSettings.slow_down_factor = slowDownPrevious; } catch { }
-            slowDownPrevious = 1;
+            restoreSlowDown(stSettings);
         });
     }
 
@@ -129,11 +158,11 @@ export class GenieController {
     }
 
     destroy() {
-        // Restore animation speed before clearing timers.
+        // Restore animation speed before clearing timers, but only if nobody
+        // else changed that process-global setting while the override was live.
         if (slowDownOwner === this) {
             slowDownOwner = null;
-            try { St.Settings.get().slow_down_factor = slowDownPrevious; } catch { }
-            slowDownPrevious = 1;
+            restoreSlowDown(St.Settings.get());
         }
         this._timers.removeAll();
         this._restoreId = 0;

--- a/interactions/tooltipManager.js
+++ b/interactions/tooltipManager.js
@@ -32,6 +32,10 @@ export class TooltipManager {
 
     style() {
         const cfg = this._getConfig();
+        if (!cfg.showTooltip) {
+            this.hide();
+            return;
+        }
         const radius = cfg.tooltipRadius ?? 9;
         const bg = cfg.highContrast ? 'rgba(0,0,0,0.98)'
             : (cfg.tooltipBg || 'rgba(32,32,36,0.92)');
@@ -49,6 +53,7 @@ export class TooltipManager {
     }
 
     scheduleShow(item, geom) {
+        if (!this._getConfig().showTooltip) { this.hide(); return; }
         if (!item) { this.hide(); return; }
         if (this._shown) { this.show(item, geom); return; }
 
@@ -64,13 +69,14 @@ export class TooltipManager {
             const nextGeom = this._pendingGeom;
             this._pendingItem = null;
             this._pendingGeom = null;
-            if (nextItem && (!this._getHoverItem || this._getHoverItem() === nextItem))
+            if (nextItem && this._getConfig().showTooltip &&
+                (!this._getHoverItem || this._getHoverItem() === nextItem))
                 this.show(nextItem, nextGeom);
         });
     }
 
     show(item, geom) {
-        if (!item) return;
+        if (!item || !this._getConfig().showTooltip) return;
         this._label.text = item.label();
         this._w = null;
         this._label.opacity = 255;

--- a/po/aqua-dock-pro.pot
+++ b/po/aqua-dock-pro.pot
@@ -22,20 +22,20 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: dock/dockItem.js:145 downloads/downloadManager.js:119
+#: dock/dockItem.js:145 downloads/downloadManager.js:121
 #: downloads/downloadsStack.js:29 downloads/panelView.js:150
-#: prefs/pages/downloadsPage.js:9 services/appTracker.js:275
+#: prefs/pages/downloadsPage.js:9 services/appTracker.js:280
 msgid "Downloads"
 msgstr ""
 
-#: dock/dockItem.js:146 downloads/downloadManager.js:122
+#: dock/dockItem.js:146 downloads/downloadManager.js:124
 #: menus/menuActions.js:33 prefs/pages/downloadsPage.js:30
-#: services/appTracker.js:285
+#: services/appTracker.js:290
 msgid "Folder"
 msgstr ""
 
-#: dock/dockItem.js:147 menus/menuActions.js:37 services/appTracker.js:353
-#: services/appTracker.js:354
+#: dock/dockItem.js:147 menus/menuActions.js:37 services/appTracker.js:358
+#: services/appTracker.js:359
 msgid "Location"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgid "All items in Trash will be permanently deleted."
 msgstr ""
 
 #: menus/menuManager.js:143 prefs/pages/aboutPage.js:71
-#: prefs/widgets/customItems.js:79
+#: prefs/widgets/customItems.js:84
 msgid "Cancel"
 msgstr ""
 
@@ -1426,231 +1426,231 @@ msgid ""
 "Right-click a preview for activation, workspace, monitor, and close actions"
 msgstr ""
 
-#: prefs/supportTools.js:11
+#: prefs/supportTools.js:12
 msgid "OK"
 msgstr ""
 
-#: prefs/supportTools.js:36
+#: prefs/supportTools.js:37
 msgid "Export AquaDockPro settings"
 msgstr ""
 
-#: prefs/supportTools.js:43 prefs/supportTools.js:59
+#: prefs/supportTools.js:46 prefs/supportTools.js:65
 msgid "Please choose a local file."
 msgstr ""
 
-#: prefs/supportTools.js:46
+#: prefs/supportTools.js:49
 msgid "Settings exported"
 msgstr ""
 
-#: prefs/supportTools.js:48
+#: prefs/supportTools.js:52
 msgid "Export failed"
 msgstr ""
 
-#: prefs/supportTools.js:54
+#: prefs/supportTools.js:58
 msgid "Import AquaDockPro settings"
 msgstr ""
 
-#: prefs/supportTools.js:61
+#: prefs/supportTools.js:67
 msgid "The selected file could not be read."
 msgstr ""
 
-#: prefs/supportTools.js:64
+#: prefs/supportTools.js:70
 msgid "This is not an AquaDockPro settings backup."
 msgstr ""
 
-#: prefs/supportTools.js:72
+#: prefs/supportTools.js:78
 #, javascript-format
 msgid "Setting “%s” has the wrong type."
 msgstr ""
 
-#: prefs/supportTools.js:83
+#: prefs/supportTools.js:89
 #, javascript-format
 msgid "Setting “%s” could not be restored."
 msgstr ""
 
-#: prefs/supportTools.js:92
+#: prefs/supportTools.js:98
 msgid "Settings imported"
 msgstr ""
 
-#: prefs/supportTools.js:93
+#: prefs/supportTools.js:99
 #, javascript-format
 msgid "%d setting was restored."
 msgid_plural "%d settings were restored."
 msgstr[0] ""
 msgstr[1] ""
 
-#: prefs/supportTools.js:96
+#: prefs/supportTools.js:103
 msgid "Import failed"
 msgstr ""
 
-#: prefs/supportTools.js:114
+#: prefs/supportTools.js:121
 msgid "Diagnostics copied"
 msgstr ""
 
-#: prefs/supportTools.js:115
+#: prefs/supportTools.js:122
 msgid "The report is ready to paste into a support request."
 msgstr ""
 
-#: prefs/widgets/rows.js:142
+#: prefs/widgets/rows.js:143
 msgid "Choose an image (PNG, JPEG, SVG…)"
 msgstr ""
 
-#: prefs/widgets/rows.js:146
+#: prefs/widgets/rows.js:147
 msgid "Choose an application icon"
 msgstr ""
 
-#: prefs/widgets/rows.js:147
+#: prefs/widgets/rows.js:148
 msgid "Images"
 msgstr ""
 
-#: prefs/widgets/rows.js:165
+#: prefs/widgets/rows.js:168
 msgid "Use the default icon"
 msgstr ""
 
-#: prefs/widgets/rows.js:177 prefs/widgets/rows.js:182
+#: prefs/widgets/rows.js:180 prefs/widgets/rows.js:185
 msgid "No folder selected"
 msgstr ""
 
-#: prefs/widgets/rows.js:186
+#: prefs/widgets/rows.js:189
 msgid "Choose"
 msgstr ""
 
-#: prefs/widgets/rows.js:188
+#: prefs/widgets/rows.js:191
 msgid "Choose a folder stack"
 msgstr ""
 
-#: prefs/widgets/customItems.js:11
+#: prefs/widgets/customItems.js:12
 msgid "Folder stack"
 msgstr ""
 
-#: prefs/widgets/customItems.js:12
+#: prefs/widgets/customItems.js:13
 msgid "File"
 msgstr ""
 
-#: prefs/widgets/customItems.js:13
+#: prefs/widgets/customItems.js:14
 msgid "Web link"
 msgstr ""
 
-#: prefs/widgets/customItems.js:14
+#: prefs/widgets/customItems.js:15
 msgid "Separator"
 msgstr ""
 
-#: prefs/widgets/customItems.js:15
+#: prefs/widgets/customItems.js:16
 msgid "Spacer"
 msgstr ""
 
-#: prefs/widgets/customItems.js:48
+#: prefs/widgets/customItems.js:49
 msgid "Add dock locations"
 msgstr ""
 
-#: prefs/widgets/customItems.js:49
+#: prefs/widgets/customItems.js:50
 msgid ""
 "Folders open as stacks; files and links open in their default application"
 msgstr ""
 
-#: prefs/widgets/customItems.js:51
+#: prefs/widgets/customItems.js:52
 msgid "Add folder"
 msgstr ""
 
-#: prefs/widgets/customItems.js:52
+#: prefs/widgets/customItems.js:53
 msgid "Add a folder stack"
 msgstr ""
 
-#: prefs/widgets/customItems.js:60
+#: prefs/widgets/customItems.js:63
 msgid "Add file"
 msgstr ""
 
-#: prefs/widgets/customItems.js:61
+#: prefs/widgets/customItems.js:64
 msgid "Add a file"
 msgstr ""
 
-#: prefs/widgets/customItems.js:69
+#: prefs/widgets/customItems.js:74
 msgid "Add web link"
 msgstr ""
 
-#: prefs/widgets/customItems.js:71
+#: prefs/widgets/customItems.js:76
 msgid "Add a web link"
 msgstr ""
 
-#: prefs/widgets/customItems.js:72
+#: prefs/widgets/customItems.js:77
 #, javascript-format
 msgid "Enter a complete address such as %s"
 msgstr ""
 
-#: prefs/widgets/customItems.js:80
+#: prefs/widgets/customItems.js:85
 msgid "Add"
 msgstr ""
 
-#: prefs/widgets/customItems.js:96
+#: prefs/widgets/customItems.js:101
 msgid "Add layout item"
 msgstr ""
 
-#: prefs/widgets/customItems.js:97
+#: prefs/widgets/customItems.js:102
 msgid "Separators draw a line; spacers add a small empty gap"
 msgstr ""
 
-#: prefs/widgets/customItems.js:99
+#: prefs/widgets/customItems.js:104
 msgid "Add separator"
 msgstr ""
 
-#: prefs/widgets/customItems.js:101
+#: prefs/widgets/customItems.js:106
 msgid "Add spacer"
 msgstr ""
 
-#: prefs/widgets/customItems.js:115
+#: prefs/widgets/customItems.js:120
 msgid "Dock item"
 msgstr ""
 
-#: prefs/widgets/customItems.js:119
+#: prefs/widgets/customItems.js:124
 msgid "Move up"
 msgstr ""
 
-#: prefs/widgets/customItems.js:127
+#: prefs/widgets/customItems.js:132
 msgid "Move down"
 msgstr ""
 
-#: prefs/widgets/customItems.js:135
+#: prefs/widgets/customItems.js:140
 msgid "Remove"
 msgstr ""
 
-#: ui/preview/previewManager.js:168
+#: ui/preview/previewManager.js:188
 #, javascript-format
 msgid "Close %s"
 msgstr ""
 
-#: ui/preview/previewManager.js:206
+#: ui/preview/previewManager.js:227
 #, javascript-format
 msgid "+%d more window"
 msgid_plural "+%d more windows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ui/preview/previewManager.js:223
+#: ui/preview/previewManager.js:244
 msgid "Previous window page"
 msgstr ""
 
-#: ui/preview/previewManager.js:232
+#: ui/preview/previewManager.js:253
 #, javascript-format
 msgid "Page %d of %d"
 msgstr ""
 
-#: ui/preview/previewManager.js:243
+#: ui/preview/previewManager.js:264
 msgid "Next window page"
 msgstr ""
 
-#: ui/preview/previewManager.js:342
+#: ui/preview/previewManager.js:363
 msgid "Activate"
 msgstr ""
 
-#: ui/preview/previewManager.js:351
+#: ui/preview/previewManager.js:372
 msgid "Move to Current Workspace"
 msgstr ""
 
-#: ui/preview/previewManager.js:366
+#: ui/preview/previewManager.js:387
 #, javascript-format
 msgid "Move to Monitor %d"
 msgstr ""
 
-#: ui/preview/previewManager.js:372
+#: ui/preview/previewManager.js:393
 msgid "Close Window"
 msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -17,6 +17,7 @@ export default class AquaDockProPreferences extends ExtensionPreferences {
         window._settings = s;
         window._settingsSignalIds = [];
         window._cleanupCallbacks = [];
+        window._dialogCancellables = new Set();
 
         window.set_default_size(740, 820);
         window.set_search_enabled(true);
@@ -31,6 +32,11 @@ export default class AquaDockProPreferences extends ExtensionPreferences {
         buildAboutPage(window, s, this.metadata);
 
         window.connect('close-request', () => {
+            for (const cancellable of (window._dialogCancellables ?? [])) {
+                try { cancellable.cancel(); } catch { }
+            }
+            window._dialogCancellables?.clear();
+
             for (const cleanup of (window._cleanupCallbacks ?? [])) {
                 try { cleanup(); } catch { }
             }

--- a/prefs/dialogLifecycle.js
+++ b/prefs/dialogLifecycle.js
@@ -1,0 +1,14 @@
+// Tracks native file-dialog operations so closing Preferences cancels callbacks
+// that would otherwise retain the window/settings objects until completion.
+
+import Gio from 'gi://Gio';
+
+export function beginDialog(window) {
+    const cancellable = new Gio.Cancellable();
+    window?._dialogCancellables?.add(cancellable);
+    return cancellable;
+}
+
+export function endDialog(window, cancellable) {
+    window?._dialogCancellables?.delete(cancellable);
+}

--- a/prefs/supportTools.js
+++ b/prefs/supportTools.js
@@ -5,6 +5,7 @@ import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk';
 
 import { _, format, ngettext } from '../core/i18n.js';
+import { beginDialog, endDialog } from './dialogLifecycle.js';
 
 function showMessage(window, heading, body) {
     const dialog = new Adw.MessageDialog({ transient_for: window, modal: true, heading, body });
@@ -36,7 +37,9 @@ export function exportSettings(window, settings, metadata) {
         title: _('Export AquaDockPro settings'),
         initial_name: `aqua-dock-pro-v${metadata.version}-settings.json`,
     });
-    dialog.save(window, null, (source, result) => {
+    const cancellable = beginDialog(window);
+    dialog.save(window, cancellable, (source, result) => {
+        endDialog(window, cancellable);
         try {
             const file = source.save_finish(result);
             const path = file?.get_path();
@@ -45,14 +48,17 @@ export function exportSettings(window, settings, metadata) {
             GLib.file_set_contents(path, text);
             showMessage(window, _('Settings exported'), path);
         } catch (e) {
-            if (!String(e).includes('Dismissed')) showMessage(window, _('Export failed'), e.message);
+            if (!cancellable.is_cancelled() && !String(e).includes('Dismissed'))
+                showMessage(window, _('Export failed'), e.message);
         }
     });
 }
 
 export function importSettings(window, settings, metadata) {
     const dialog = new Gtk.FileDialog({ title: _('Import AquaDockPro settings') });
-    dialog.open(window, null, (source, result) => {
+    const cancellable = beginDialog(window);
+    dialog.open(window, cancellable, (source, result) => {
+        endDialog(window, cancellable);
         try {
             const file = source.open_finish(result);
             const path = file?.get_path();
@@ -93,7 +99,8 @@ export function importSettings(window, settings, metadata) {
                 format(ngettext('%d setting was restored.', '%d settings were restored.',
                     parsed.length), parsed.length));
         } catch (e) {
-            if (!String(e).includes('Dismissed')) showMessage(window, _('Import failed'), e.message);
+            if (!cancellable.is_cancelled() && !String(e).includes('Dismissed'))
+                showMessage(window, _('Import failed'), e.message);
         }
     });
 }

--- a/prefs/widgets/customItems.js
+++ b/prefs/widgets/customItems.js
@@ -6,6 +6,7 @@ import Gtk from 'gi://Gtk';
 
 import { _, format } from '../../core/i18n.js';
 import { parseCustomItems, serializeCustomItems } from '../../services/customItems.js';
+import { beginDialog, endDialog } from '../dialogLifecycle.js';
 
 const TYPE_LABELS = {
     folder: _('Folder stack'),
@@ -50,7 +51,9 @@ export function buildCustomItemsEditor(window, settings, group) {
     });
     locationControls.add_suffix(button('folder-new-symbolic', _('Add folder'), () => {
         const dialog = new Gtk.FileDialog({ title: _('Add a folder stack'), modal: true });
-        dialog.select_folder(window, null, (source, result) => {
+        const cancellable = beginDialog(window);
+        dialog.select_folder(window, cancellable, (source, result) => {
+            endDialog(window, cancellable);
             try {
                 const file = source.select_folder_finish(result);
                 if (file) add({ type: 'folder', uri: file.get_uri(), name: file.get_basename() ?? '' });
@@ -59,7 +62,9 @@ export function buildCustomItemsEditor(window, settings, group) {
     }));
     locationControls.add_suffix(button('document-open-symbolic', _('Add file'), () => {
         const dialog = new Gtk.FileDialog({ title: _('Add a file'), modal: true });
-        dialog.open(window, null, (source, result) => {
+        const cancellable = beginDialog(window);
+        dialog.open(window, cancellable, (source, result) => {
+            endDialog(window, cancellable);
             try {
                 const file = source.open_finish(result);
                 if (file) add({ type: 'file', uri: file.get_uri(), name: file.get_basename() ?? '' });

--- a/prefs/widgets/rows.js
+++ b/prefs/widgets/rows.js
@@ -6,6 +6,7 @@ import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
 import { _ } from '../../core/i18n.js';
+import { beginDialog, endDialog } from '../dialogLifecycle.js';
 
 // Integer or fractional spinner. `digits` 0 → whole numbers (px/ms); ≥1 →
 // fractional control for continuous values (factors, opacity, damping…).
@@ -151,11 +152,13 @@ export function iconChooserRow(window, s, key, title) {
         filters.append(filter);
         dialog.set_filters(filters);
         dialog.set_default_filter(filter);
-        dialog.open(window, null, (d, res) => {
+        const cancellable = beginDialog(window);
+        dialog.open(window, cancellable, (d, res) => {
+            endDialog(window, cancellable);
             try {
                 const file = d.open_finish(res);
                 if (file) s.set_string(key, file.get_path());
-            } catch { /* dismissed */ }
+            } catch { /* dismissed or cancelled */ }
         });
     });
     row.add_suffix(browse);
@@ -186,11 +189,13 @@ export function folderChooserRow(window, s, key, title, subtitle) {
     const choose = new Gtk.Button({ label: _('Choose'), valign: Gtk.Align.CENTER });
     choose.connect('clicked', () => {
         const dialog = new Gtk.FileDialog({ title: _('Choose a folder stack'), modal: true });
-        dialog.select_folder(window, null, (source, result) => {
+        const cancellable = beginDialog(window);
+        dialog.select_folder(window, cancellable, (source, result) => {
+            endDialog(window, cancellable);
             try {
                 const folder = source.select_folder_finish(result);
                 if (folder) s.set_string(key, folder.get_uri());
-            } catch { /* dismissed */ }
+            } catch { /* dismissed or cancelled */ }
         });
     });
     row.add_suffix(choose);

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -97,6 +97,7 @@ gjs -m tests/iconResolution.test.js
 gjs -m tests/layout.test.js
 gjs -m tests/fullscreenPolicy.test.js
 gjs -m tests/settings.test.js
+gjs -m tests/animationEngine.test.js
 gjs -m tests/fileEnumerator.test.js
 gjs -m tests/fileClipboard.test.js
 gjs -m tests/fanGeometry.test.js

--- a/services/appTracker.js
+++ b/services/appTracker.js
@@ -4,7 +4,7 @@ import Gio from 'gi://Gio';
 import Shell from 'gi://Shell';
 import * as AppFavorites from 'resource:///org/gnome/shell/ui/appFavorites.js';
 
-import { SignalGroup, appWindowsForConfig } from '../core/utils.js';
+import { SignalGroup, appWindowsForConfig, logError } from '../core/utils.js';
 import { _ } from '../core/i18n.js';
 import { downloadsDir } from './fileService.js';
 import { LocationResolver } from './locationResolver.js';
@@ -128,26 +128,31 @@ class AppStateHub {
         this._windowSignals.clear();
     }
 
+    _notify(record, context) {
+        try { record.callback(); }
+        catch (error) { logError(error, `AppStateHub ${context}`); }
+    }
+
     _emitAll() {
         for (const record of [...this._subscribers])
-            record.callback();
+            this._notify(record, 'all');
     }
 
     _emitWorkspace() {
         for (const record of [...this._subscribers])
-            if (record.isolateWS) record.callback();
+            if (record.isolateWS) this._notify(record, 'workspace');
     }
 
     _emitMonitor(monitorIndex) {
         for (const record of [...this._subscribers])
             if (record.isolateMonitors && record.monitorIndex === monitorIndex)
-                record.callback();
+                this._notify(record, 'monitor');
     }
 
     _emitOptional() {
         for (const record of [...this._subscribers])
             if (record.isolateWS || record.isolateMonitors)
-                record.callback();
+                this._notify(record, 'window');
     }
 
     destroy() {

--- a/services/fileService.js
+++ b/services/fileService.js
@@ -90,8 +90,15 @@ async function deleteChildren(dir, cancellable, result) {
     }
     for (;;) {
         let infos;
-        try { infos = await en.next_files_async(32, GLib.PRIORITY_DEFAULT, cancellable); }
-        catch { break; }
+        try {
+            infos = await en.next_files_async(32, GLib.PRIORITY_DEFAULT, cancellable);
+        } catch (error) {
+            if (!cancellable.is_cancelled()) {
+                result.failed++;
+                logError(error, 'emptyTrash enumerate');
+            }
+            break;
+        }
         if (!infos.length) break;
         for (const info of infos) {
             if (cancellable.is_cancelled()) break;

--- a/services/locationResolver.js
+++ b/services/locationResolver.js
@@ -3,7 +3,7 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
-import { TimeoutGroup } from '../core/utils.js';
+import { TimeoutGroup, logError } from '../core/utils.js';
 
 const ATTRIBUTES = [
     Gio.FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
@@ -109,8 +109,10 @@ export class LocationResolver {
         if (this._notifyId) return;
         this._notifyId = this._timers.addIdle(() => {
             this._notifyId = 0;
-            for (const listener of [...this._listeners])
-                listener();
+            for (const listener of [...this._listeners]) {
+                try { listener(); }
+                catch (error) { logError(error, 'LocationResolver listener'); }
+            }
             return GLib.SOURCE_REMOVE;
         });
     }

--- a/services/mountedDevices.js
+++ b/services/mountedDevices.js
@@ -284,6 +284,16 @@ function entriesFingerprint(entries) {
     ].join('\u0001')).join('\u0002');
 }
 
+function sameStoreEntries(previous, next, previousFingerprint, nextFingerprint) {
+    if (previousFingerprint !== nextFingerprint || previous.length !== next.length)
+        return false;
+    for (let i = 0; i < next.length; i++) {
+        if (previous[i].key !== next[i].key || previous[i].mount !== next[i].mount)
+            return false;
+    }
+    return true;
+}
+
 export function reconcileMountedDeviceEntries(previous, next) {
     const previousByKey = new Map(previous.map(entry => [entry.key, entry]));
     return next.map(entry => {
@@ -302,6 +312,7 @@ class MountedDeviceStore {
         this._timers = new TimeoutGroup();
         this._refreshId = 0;
         this._entries = this._readEntries();
+        this._fingerprint = entriesFingerprint(this._entries);
     }
 
     get empty() { return this._callbacks.size === 0; }
@@ -353,9 +364,17 @@ class MountedDeviceStore {
 
     _refresh() {
         if (!this._monitor) return;
-        this._entries = this._readEntries();
-        for (const callback of [...this._callbacks])
-            callback(this._entries);
+        const entries = this._readEntries();
+        const fingerprint = entriesFingerprint(entries);
+        if (sameStoreEntries(this._entries, entries, this._fingerprint, fingerprint))
+            return;
+
+        this._entries = entries;
+        this._fingerprint = fingerprint;
+        for (const callback of [...this._callbacks]) {
+            try { callback(this._entries); }
+            catch (error) { console.error(`AquaDockPro: [mounted device subscriber] ${error}`); }
+        }
     }
 
     _disconnect() {
@@ -370,6 +389,7 @@ class MountedDeviceStore {
         this._disconnect();
         this._callbacks.clear();
         this._entries = [];
+        this._fingerprint = '';
         this._monitor = null;
     }
 }

--- a/services/notificationService.js
+++ b/services/notificationService.js
@@ -78,7 +78,8 @@ class NotificationHub {
         this._tray = messageTray();
         this._trayIds = [];
         this._sourceSignals = new Map();
-        this._reliable = Boolean(this._tray);
+        this._baseReliable = Boolean(this._tray);
+        this._reliable = this._baseReliable;
         this._map = buildNotificationMap();
 
         if (this._tray) this._connect();
@@ -121,13 +122,14 @@ class NotificationHub {
         } catch { }
         if (addedId) this._trayIds.push(addedId);
         if (removedId) this._trayIds.push(removedId);
-        if (!addedId || !removedId) this._reliable = false;
+        if (!addedId || !removedId) this._baseReliable = false;
 
         try {
             for (const source of messageTraySources()) this._watchSource(source);
         } catch {
-            this._reliable = false;
+            this._baseReliable = false;
         }
+        this._updateReliability();
     }
 
     _watchSource(source) {
@@ -143,17 +145,33 @@ class NotificationHub {
         if (countId) ids.push(countId);
         if (addedId) ids.push(addedId);
         if (removedId) ids.push(removedId);
-        if (!countId && !(addedId && removedId)) this._reliable = false;
-        if (ids.length) this._sourceSignals.set(source, ids);
+        const reliable = Boolean(countId || (addedId && removedId));
+        this._sourceSignals.set(source, { ids, reliable });
+        this._updateReliability();
     }
 
     _unwatchSource(source) {
-        const ids = this._sourceSignals.get(source);
-        if (!ids) return;
+        const record = this._sourceSignals.get(source);
+        if (!record) return;
         this._sourceSignals.delete(source);
-        for (const id of ids) {
+        for (const id of record.ids) {
             try { source.disconnect(id); } catch { }
         }
+        this._updateReliability();
+    }
+
+    _updateReliability() {
+        if (!this._baseReliable) {
+            this._reliable = false;
+            return;
+        }
+        for (const record of this._sourceSignals.values()) {
+            if (!record.reliable) {
+                this._reliable = false;
+                return;
+            }
+        }
+        this._reliable = true;
     }
 
     _refresh(notify) {
@@ -181,6 +199,8 @@ class NotificationHub {
         this._trayIds = [];
         this._callbacks.clear();
         this._tray = null;
+        this._baseReliable = false;
+        this._reliable = false;
         this._map = new Map();
     }
 }

--- a/tests/animationEngine.test.js
+++ b/tests/animationEngine.test.js
@@ -1,0 +1,38 @@
+import { AnimationEngine } from '../animation/animationEngine.js';
+import { setReduceMotionOverride } from '../core/utils.js';
+
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+const engine = new AnimationEngine();
+const scheduler = {
+    started: 0,
+    stopped: 0,
+    running: false,
+    start() { this.started++; this.running = true; },
+    stop() { this.stopped++; this.running = false; },
+    isRunning() { return this.running; },
+    destroy() { this.running = false; },
+};
+engine._scheduler = scheduler;
+
+try {
+    // AnimationEngine starts with an enabled cache. The direct settings path
+    // updates the process-wide override and then calls kick() without setModel().
+    // kick() must refresh that cache and stop immediately.
+    setReduceMotionOverride(true);
+    engine.kick();
+
+    assert(engine._animate === false,
+        'reduce-motion direct update did not refresh the animation mode');
+    assert(scheduler.stopped === 1,
+        'reduce-motion direct update did not stop the active frame scheduler');
+    assert(scheduler.started === 0,
+        'reduce-motion direct update unexpectedly started the frame scheduler');
+} finally {
+    setReduceMotionOverride(false);
+    engine.destroy();
+}
+
+print('animationEngine: ok');

--- a/ui/preview/previewManager.js
+++ b/ui/preview/previewManager.js
@@ -36,6 +36,7 @@ export class PreviewManager {
         this._timers = new TimeoutGroup();
         this._openId = 0;
         this._graceId = 0;
+        this._windowRefreshId = 0;
         this._pendingItem = null;
         this._windowMenu = null;
         this._windowMenuManager = null;
@@ -89,6 +90,16 @@ export class PreviewManager {
             try { actor = w.get_compositor_private?.(); } catch { }
             try { rect = w.get_frame_rect(); } catch { }
             return actor && rect && rect.width > 0 && rect.height > 0;
+        });
+    }
+
+    _queueWindowRefresh(item, box, forceAll, page, focusPreview) {
+        if (this._windowRefreshId) return;
+        this._windowRefreshId = this._timers.addIdle(() => {
+            this._windowRefreshId = 0;
+            if (this._box === box)
+                this._build(item, true, forceAll, page, focusPreview);
+            return false;
         });
     }
 
@@ -157,6 +168,15 @@ export class PreviewManager {
                 x_expand: true,
             });
             title.set_style(titleStyle);
+
+            // A window can disappear while its preview is open. Rebuild on the
+            // next idle turn so the clone is never left pointing at a dead
+            // compositor actor. connectObject ties this signal to the popup.
+            try {
+                win.connectObject('unmanaging', () =>
+                    this._queueWindowRefresh(item, box, forceAll, page, focusPreview), box);
+            } catch { }
+
             if (cfg.previewCloseButtons) {
                 const titleRow = new St.BoxLayout({ x_expand: true });
                 titleRow.get_layout_manager().set_spacing(5);
@@ -184,7 +204,8 @@ export class PreviewManager {
                     this._openWindowMenu(btn, win, box);
                     return;
                 }
-                win.activate(global.get_current_time());
+                try { win.activate(global.get_current_time()); }
+                catch (e) { logError(e, 'preview activate window'); }
                 this.hide(true);
             });
             if (cfg.previewWindowActions) {
@@ -510,6 +531,7 @@ export class PreviewManager {
         this._timers.removeAll();
         this._openId = 0;
         this._graceId = 0;
+        this._windowRefreshId = 0;
         this._pendingItem = null;
         this._destroyWindowMenu();
         if (this._dying) { this._destroyBox(this._dying); this._dying = null; }


### PR DESCRIPTION
## What changed

This fixes the runtime/lifecycle issues found in the full repository audit while preserving the dock's existing appearance and interaction design.

- refresh Reduce Motion immediately through the optimized direct-settings path
- prune intellihide window subscriptions when windows leave the dock's monitor/workspace scope
- recover notification signal reliability after temporary incompatible sources disappear
- isolate shared app/location/mounted-device subscribers so one callback cannot block other docks
- report Trash enumeration failures instead of incorrectly showing a full success
- rebuild live window previews when a window is unmanaged and guard close-vs-activate races
- show the real total item count in Downloads panels
- immediately cancel/hide stale tooltips and close transient popups when their presentation settings change
- suppress true no-op mounted-device refresh fan-out while still detecting replacement mount objects
- restrict pressure-reveal sampling to the target monitor edge
- make DockFactory rebuilds transactional on construction/refresh failures
- keep the frame scheduler alive indefinitely only while animation work exists
- preserve external changes to GNOME's global animation speed while the Genie effect temporarily owns it
- make DownloadManager safe for disable -> enable on the same instance
- cancel native Preferences file/folder dialogs when the Preferences window closes
- add a regression test ensuring Reduce Motion takes effect without a relayout

## Visual and behavior safety

This intentionally does **not** change dock geometry, CSS, icon sizing, magnification math, spring constants, animation durations, easing curves, indicator visuals, popup dimensions, or input mappings. Existing transient popups are closed rather than mutated live when their settings change; the next open uses the new configuration cleanly.

The previously discussed extension-wide WM/display event-hub refactor is intentionally not included because it crosses sensitive fullscreen/intellihide ordering and is an optimization rather than a correctness fix.

## Validation

The existing validation workflow will run syntax/static checks, unit tests, Preferences smoke testing, extension packaging, and package auditing. The new Reduce Motion regression test is wired into `scripts/validate.sh`.