### PR TITLE
Add GNOME Shell 51 compatibility without regressing Shell 50

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,8 +6,19 @@ on:
 
 jobs:
   extension:
+    name: Extension (${{ matrix.shell }})
     runs-on: ubuntu-latest
-    container: fedora:44
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shell: GNOME 50
+            image: fedora:44
+            major: "50"
+          - shell: GNOME 51
+            image: fedora:45
+            major: "51"
+    container: ${{ matrix.image }}
 
     steps:
       - name: Install Git
@@ -17,6 +28,13 @@ jobs:
 
       - name: Install validation dependencies
         run: dnf install -y gjs glib2 gettext jq gnome-shell libadwaita python3 unzip xorg-x11-server-Xvfb
+
+      - name: Verify GNOME Shell version
+        run: |
+          shell_version="$(gnome-shell --version)"
+          printf '%s\n' "$shell_version"
+          shell_major="$(printf '%s\n' "$shell_version" | sed -E 's/.* ([0-9]+).*/\1/')"
+          test "$shell_major" = "${{ matrix.major }}"
 
       - name: EGO compatibility audit
         run: python3 scripts/ego-audit.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 267
+
+- Advertise one extension package for GNOME Shell 50 and 51 while preserving the existing Shell 50 runtime path and behavior.
+- Route native GNOME application menus through a version-aware popup compatibility boundary so Shell 50 keeps `PopupAnimation` semantics while Shell 51 uses the new `{ animate }` options object.
+- Read GNOME 51's `St.Settings.reducedMotion` property with the existing Shell 50-safe fallback, add guards for APIs removed by Shell 51, and validate/package on both Fedora 44 / GNOME 50 and Fedora 45 / GNOME 51.
+
 ## 266
 
 - Make the right-click context menu for real Downloads and custom-folder stack items show only `Copy`; remove the redundant `Open` action from that menu.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <br/>
 
-[![GNOME Shell](https://img.shields.io/badge/GNOME_Shell-50-5294E2?style=for-the-badge&logo=gnome&logoColor=white)](https://extensions.gnome.org)
+[![GNOME Shell](https://img.shields.io/badge/GNOME_Shell-50_%7C_51-5294E2?style=for-the-badge&logo=gnome&logoColor=white)](https://extensions.gnome.org)
 [![JavaScript](https://img.shields.io/badge/JavaScript-GJS-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)](https://gjs.guide/)
 [![GTK](https://img.shields.io/badge/GTK-4.0-4A90D9?style=for-the-badge&logo=gtk&logoColor=white)](https://gtk.org)
 [![License](https://img.shields.io/badge/License-MIT-00C9C8?style=for-the-badge)](LICENSE)
@@ -36,7 +36,7 @@
 
 Aqua Dock Pro is a customizable GNOME Shell dock with smooth magnification, spring-based motion, live window previews, intellihide, folder stacks, notification badges, mounted devices and multi-monitor support.
 
-Currently focused on **GNOME Shell 50 + Wayland**.
+Currently focused on **GNOME Shell 50 and 51 + Wayland**.
 
 > 🧪 Around **3–4 months of work and 250+ install/test/debug cycles** so far.
 
@@ -215,7 +215,7 @@ Settings can also be **exported/imported as JSON** or reset to defaults.
 
 | | |
 |---|---|
-| **GNOME** | GNOME Shell 50 |
+| **GNOME** | GNOME Shell 50 / 51 |
 | **Language** | JavaScript / GJS |
 | **Shell UI** | St + Clutter |
 | **Preferences** | GTK 4 + Libadwaita |
@@ -259,6 +259,7 @@ The areas I'm still working on most are **animations, intellihide, window previe
 
 - Fedora Linux
 - GNOME Shell 50
+- GNOME Shell 51 compatibility suite in Fedora 45 CI
 - Wayland
 - Intel integrated graphics
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,9 +1,8 @@
 # Support
 
-AquaDockPro currently targets GNOME Shell 50 and the GNOME Shell 51 beta on
-Wayland. Xwayland applications are supported, but GNOME Shell 50 no longer
-provides an X11 session. The stable `51` metadata entry will be shipped only
-after GNOME 51.0 is released and retested.
+AquaDockPro targets GNOME Shell 50 and GNOME Shell 51 on Wayland with the same
+extension package. Xwayland applications are supported, but GNOME Shell 50 no
+longer provides an X11 session.
 
 Before reporting a problem:
 

--- a/compat/shell.js
+++ b/compat/shell.js
@@ -1,8 +1,30 @@
 // AquaDockPro GNOME Shell compatibility boundary.
 
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+import * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { warnOnce } from '../core/utils.js';
+
+const SHELL_MAJOR = Number.parseInt(Config.PACKAGE_VERSION, 10) || 0;
+
+export function shellMajorVersion() {
+    return SHELL_MAJOR;
+}
+
+// GNOME Shell 51 changed PopupMenu.open()/close() from a PopupAnimation enum
+// argument to an options object. Keep that ABI difference confined here so the
+// same extension package remains correct on both GNOME Shell 50 and 51+.
+export function openPopupMenu(menu, animate = true) {
+    if (typeof menu?.open !== 'function') return;
+    if (SHELL_MAJOR >= 51) {
+        menu.open({ animate: animate !== false });
+        return;
+    }
+    menu.open(animate === false
+        ? BoxPointer.PopupAnimation.NONE
+        : BoxPointer.PopupAnimation.FULL);
+}
 
 export function overviewDash() {
     const dash = Main.overview?.dash ?? null;

--- a/core/utils.js
+++ b/core/utils.js
@@ -140,10 +140,12 @@ export function animationsEnabled() {
         const settings = _stSettings ??= St.Settings.get();
         if (!settings.enable_animations) return false;
 
-        // GNOME 51 adds a separate reduced-motion preference. Keep this
-        // feature check so the same package continues to run on GNOME 50.
+        // GNOME 51 adds a separate reduced-motion preference. GJS exposes the
+        // new property as reducedMotion; keep the underscore fallback for older
+        // bindings so one package remains safe across Shell 50 and 51.
         const reduce = St.ReducedMotion?.REDUCE;
-        return reduce === undefined || settings.reduced_motion !== reduce;
+        const reducedMotion = settings.reducedMotion ?? settings.reduced_motion;
+        return reduce === undefined || reducedMotion !== reduce;
     }
     catch { return true; }
 }

--- a/menus/menuManager.js
+++ b/menus/menuManager.js
@@ -5,7 +5,6 @@ import Clutter from 'gi://Clutter';
 import St from 'gi://St';
 
 import { AppMenu } from 'resource:///org/gnome/shell/ui/appMenu.js';
-import * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Dialog from 'resource:///org/gnome/shell/ui/dialog.js';
 import * as ModalDialog from 'resource:///org/gnome/shell/ui/modalDialog.js';
@@ -15,7 +14,7 @@ import { populateMenu } from './menuActions.js';
 import { appWindowsForConfig, TimeoutGroup } from '../core/utils.js';
 import { _, format, ngettext } from '../core/i18n.js';
 import { emptyTrash } from '../services/fileService.js';
-import { notifyUser } from '../compat/shell.js';
+import { notifyUser, openPopupMenu } from '../compat/shell.js';
 
 export class MenuManager {
     // host: { container, getConfig, getGeom, isLayoutLocked, onOpen, onClose,
@@ -86,16 +85,16 @@ export class MenuManager {
 
     _openGnomeAppMenu(item, anchor, side) {
         try {
-            // This is the same GNOME Shell AppMenu class and the same options
-            // used by GNOME 50's DashIcon. Only the arrow side follows the dock
-            // edge so vertical AquaDockPro layouts remain usable.
+            // Use GNOME Shell's exported native AppMenu on both Shell 50 and
+            // 51. The compatibility boundary handles the open() ABI change;
+            // only the arrow side follows the dock edge for vertical layouts.
             this._menu = new AppMenu(anchor, side, {
                 favoritesSection: true,
                 showSingleWindows: true,
             });
             this._menu.setApp(item.entry.app);
             this._attachMenu(item);
-            this._menu.open(BoxPointer.PopupAnimation.FULL);
+            openPopupMenu(this._menu);
         } catch (error) {
             this._destroyMenu();
             throw error;

--- a/metadata.json
+++ b/metadata.json
@@ -3,10 +3,11 @@
   "name": "AquaDockPro",
   "description": "A premium, high-performance Dock for GNOME Shell. Gaussian magnification physics, spring animations, folder stacks, live window previews, genie minimize effect, multi-position support, attention bouncing, and notification badges. The preferences window copies a locally generated diagnostics report to the clipboard only when requested. Folder-stack Copy writes the selected item's standard file URI list to the clipboard only after the user chooses Copy.",
   "shell-version": [
-    "50"
+    "50",
+    "51"
   ],
   "settings-schema": "org.gnome.shell.extensions.aqua-dock-pro",
   "gettext-domain": "aqua-dock-pro",
   "url": "https://github.com/sahid-code404/aqua-dock-pro",
-  "version": 266
+  "version": 267
 }

--- a/scripts/audit-package.sh
+++ b/scripts/audit-package.sh
@@ -53,10 +53,10 @@ jq -e '
     .uuid == "aqua-dock-pro@shaque" and
     .name == "AquaDockPro" and
     .url == "https://github.com/sahid-code404/aqua-dock-pro" and
-    ."shell-version" == ["50"] and
+    ."shell-version" == ["50", "51"] and
     (."session-modes"? == null)
 ' "$metadata" >/dev/null || {
-    printf 'Packaged metadata is not EGO-compatible.\n' >&2
+    printf 'Packaged metadata is not EGO-compatible for GNOME Shell 50 and 51.\n' >&2
     exit 1
 }
 

--- a/scripts/ego-audit.py
+++ b/scripts/ego-audit.py
@@ -153,12 +153,40 @@ def main() -> int:
         r"\beval\s*\(|\bnew\s+Function\s*\(",
     )
 
+    # GNOME Shell 51 removals and lifecycle changes. These checks are narrow on
+    # purpose: GNOME 50 remains supported, and APIs that are merely deprecated
+    # but still supported on Shell 51 are not rejected here.
+    errors += fail_matches(
+        "GNOME-51 removed Shell.GLSLEffect",
+        runtime,
+        r"\bShell\.GLSLEffect\b",
+    )
+    errors += fail_matches(
+        "GNOME-51 removed Clutter.get_default_backend()",
+        runtime,
+        r"\bClutter\.get_default_backend\s*\(",
+    )
+    errors += fail_matches(
+        "GNOME-51 removed pointerWatcher module",
+        runtime,
+        r"resource:///org/gnome/shell/ui/pointerWatcher\.js",
+    )
+    errors += fail_matches(
+        "GNOME-51 async extension disable()",
+        {Path("extension.js")},
+        r"\basync\s+disable\s*\(",
+    )
+    errors += fail_matches(
+        "GNOME-51 legacy popup animation argument",
+        runtime,
+        r"\.(?:open|close)\s*\(\s*BoxPointer\.PopupAnimation",
+    )
+
     metadata = json.loads((ROOT / "metadata.json").read_text(encoding="utf-8"))
     shell_versions = metadata.get("shell-version")
-    if shell_versions != ["50"]:
+    if shell_versions != ["50", "51"]:
         errors.append(
-            "metadata shell-version must be ['50'] for this EGO submission; "
-            "do not advertise GNOME 51 until EGO accepts that release target"
+            "metadata shell-version must be ['50', '51'] for the dual-version EGO package"
         )
     if metadata.get("url") != "https://github.com/sahid-code404/aqua-dock-pro":
         errors.append("metadata url must point to the public source repository")

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -11,7 +11,7 @@ glib-compile-schemas --strict --targetdir="$schema_dir" schemas
 jq -e '
     .uuid == "aqua-dock-pro@shaque" and
     (.version | type == "number") and
-    ."shell-version" == ["50"] and
+    ."shell-version" == ["50", "51"] and
     (.description | contains("clipboard"))
 ' metadata.json >/dev/null
 
@@ -43,6 +43,28 @@ fi
 if grep -nE 'imports\.(ByteArray|byteArray|Lang|lang|Mainloop|mainloop)|run_dispose[[:space:]]*\(' \
     "${js_files[@]}"; then
     printf 'Deprecated or reviewer-hostile GJS API usage found.\n' >&2
+    exit 1
+fi
+
+# GNOME Shell 51 removed these APIs. Keep them out of runtime code while the
+# same package continues to support Shell 50.
+if grep -nE 'Shell\.GLSLEffect|Clutter\.get_default_backend[[:space:]]*\(|resource:///org/gnome/shell/ui/pointerWatcher\.js' \
+    "${runtime_js[@]}"; then
+    printf 'GNOME Shell 51-removed API usage found.\n' >&2
+    exit 1
+fi
+
+# GNOME Shell requires extension disable() to remain synchronous.
+if grep -nE 'async[[:space:]]+disable[[:space:]]*\(' extension.js; then
+    printf 'Extension disable() must remain synchronous for GNOME Shell 51.\n' >&2
+    exit 1
+fi
+
+# Shell 51 changed PopupMenu.open()/close() to an options object. Direct enum
+# calls outside the compatibility boundary would work on 50 but break on 51.
+if grep -nE '\.(open|close)[[:space:]]*\([[:space:]]*BoxPointer\.PopupAnimation' \
+    "${runtime_js[@]}"; then
+    printf 'GNOME Shell 50-only PopupAnimation call found; route it through compat/shell.js.\n' >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- advertise GNOME Shell 50 and 51 from the same extension package (v267)
- keep GNOME Shell 50 behavior intact through a version-aware compatibility boundary
- adapt the GNOME native `AppMenu` popup call for Shell 51's new `{ animate }` API while retaining Shell 50 `PopupAnimation` behavior
- read GNOME 51's `St.Settings.reducedMotion` property with a Shell 50-safe fallback
- add static guards for APIs removed by GNOME Shell 51 and for async `disable()` regressions
- require dual-version metadata in validation and packaged EGO bundles
- run the validation/package suite on Fedora 44 / GNOME 50 and Fedora 45 / GNOME 51
- update support documentation and changelog for the dual-version release

## Compatibility strategy

The port changes only APIs that are actually incompatible with Shell 51. APIs that GNOME 51 still supports, including the legacy `St.ButtonMask` aliases and actor key-event signals, are intentionally left unchanged to minimize regression risk on Shell 50.

## Release

- extension version: 267
- shell-version: `50`, `51`
- base branch remains unchanged until this PR is validated
